### PR TITLE
Simple unit test & minor module refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,11 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_data_stream"></a> [data\_stream](#output\_data\_stream) | n/a |
+| <a name="output_iam_roles"></a> [iam\_roles](#output\_iam\_roles) | n/a |
+| <a name="output_log_subscriptions"></a> [log\_subscriptions](#output\_log\_subscriptions) | n/a |
 <!-- END_TF_DOCS -->
 
 [Standards Link]: https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-report/modernisation-platform-terraform-module-template "Repo standards badge."

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ resource "random_id" "name" {
 resource "aws_kms_key" "firehose" {
   # checkov:skip=CKV_AWS_7
   description             = "KMS key for Firehose delivery streams"
-  deletion_window_in_days = 0
+  deletion_window_in_days = 7
   policy                  = data.aws_iam_policy_document.firehose-key-policy.json
   tags                    = var.tags
 }
@@ -93,10 +93,10 @@ resource "aws_cloudwatch_log_group" "kinesis" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "cloudwatch-to-firehose" {
-  for_each        = toset(var.cloudwatch_log_group_names)
+  count           = length(var.cloudwatch_log_group_names)
   destination_arn = aws_kinesis_firehose_delivery_stream.firehose-to-s3.arn
   filter_pattern  = var.cloudwatch_filter_pattern
-  log_group_name  = each.key
-  name            = "firehose-delivery-${each.key}-${random_id.name.hex}"
+  log_group_name  = element(var.cloudwatch_log_group_names, count.index)
+  name            = "firehose-delivery-${element(var.cloudwatch_log_group_names, count.index)}-${random_id.name.hex}"
   role_arn        = aws_iam_role.cloudwatch-to-firehose.arn
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,14 @@
+output "data_stream" {
+  value = aws_kinesis_firehose_delivery_stream.firehose-to-s3
+}
+
+output "log_subscriptions" {
+  value = aws_cloudwatch_log_subscription_filter.cloudwatch-to-firehose
+}
+
+output "iam_roles" {
+  value = {
+    "cloudwatch-to-firehose" = aws_iam_role.cloudwatch-to-firehose,
+    "firehose-to-s3" = aws_iam_role.firehose-to-s3
+  }
+}

--- a/test/unit-test/.terraform.lock.hcl
+++ b/test/unit-test/.terraform.lock.hcl
@@ -1,0 +1,65 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.65.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:N+jcGqwi8OM9t62qEfJvwrzs+XANdPfYWWqz4RkPwDQ=",
+    "zh:036f8557c8c9b58656e1ec08ed5702e44bd338fda17dc4b2add40b234102e29a",
+    "zh:0ba0708ece98735540070899a916b7a90c5c887be31ffd693ee1359e40245978",
+    "zh:12d82a82ae0e3bc580f2be961078e89d129e12df7dd82a6ec610a2b945bba1a4",
+    "zh:1ed0ee17df8807aef64976e2a4276d2a3e1d54efeae2a86f596d12eccb94dc83",
+    "zh:36b7c61a83d24f612156b4648027ba8bd5727f0ed57183cbad0e6c93b7503aa2",
+    "zh:496d06a089b1bc8d60995e8dddfe1d87c605a208f377a60b17987e89381dafda",
+    "zh:4e9aba435994589befe4279927c71a461a52e6cd96b8f0437295c18c50f6baff",
+    "zh:71134031288a312db1804d4798b10f106a843c36aafd7b8fe8f4859156d7df93",
+    "zh:748d0dbdfbe8df4b516a09b23b3981c19cef9a255c1ca0187e84ab424e6bd845",
+    "zh:783541ff77f4e7c74c817e0e2989ebdb45dd6e2c9853a8cccbcf5f1976736a76",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:af3f080975d5ed79917b8238cc0ae3150da688bc89e12dcc3ee85134b29857d0",
+    "zh:ec542372c3ffbfc3df6966f77357f8af7319d4bd956ff8e9fde0bbd124352e34",
+    "zh:f3dc7b2b5b55173207c2fd35ed6bb8cc66b06af777e221060ca2f0c0afdecbb5",
+    "zh:f9631ecc21d6e5cf82ef6ef8d14c39e1dfb2a52cc8f0abb684311885ffdb79a1",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/http" {
+  version     = "3.4.4"
+  constraints = "~> 3.3"
+  hashes = [
+    "h1:WSgOdMqgN48NIZy0CTKY2hMTNdc4rChYPUDEWYXeaTQ=",
+    "zh:28910c348aff60df15cb70c2838c5dac463de5d52fe41a511f122b0b5fa6032d",
+    "zh:61ddcdb703900b01a8d38c67bd68304e87e05aa82c2d6636a5c49813b0cee8bf",
+    "zh:6d7ba9fcebff1079b9cbad066874d83680a4aedc997baa597927f59b29a69186",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:82caa166f57808dd8421e9edf51bca0692135ca06ab548d5a2e3fe612bdd45a6",
+    "zh:95cb8ece59966d8f4020660879728dabaa158b3d188f22c0b92229347e740346",
+    "zh:ae56558b4262a4de250eec83e200ea4647badde10d1a14ed273f4daff650336f",
+    "zh:c1c5051eab9d9759fdb31bca6d7575a693558887a1156fa5f268963e05be4d92",
+    "zh:c90234ce3877e54be5b43493f51b582c6f9cb09138844cb048f63e9cd9f230fa",
+    "zh:cb237c6c47f085bf15149d6d2727b8bf108267582a30e7e2cd7393115896d003",
+    "zh:e7d782985f8b422cf265a856541ddb14f0d3ab0b54eb1aad6087ccfedacc7335",
+    "zh:ed0cc12d15226499fc7d173ad2b156c1934efae718cf254e79ca7f0ccd686b6d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.6.2"
+  constraints = "~> 3.4"
+  hashes = [
+    "h1:R5qdQjKzOU16TziCN1vR3Exr/B+8WGK80glLTT4ZCPk=",
+    "zh:0ef01a4f81147b32c1bea3429974d4d104bbc4be2ba3cfa667031a8183ef88ec",
+    "zh:1bcd2d8161e89e39886119965ef0f37fcce2da9c1aca34263dd3002ba05fcb53",
+    "zh:37c75d15e9514556a5f4ed02e1548aaa95c0ecd6ff9af1119ac905144c70c114",
+    "zh:4210550a767226976bc7e57d988b9ce48f4411fa8a60cd74a6b246baf7589dad",
+    "zh:562007382520cd4baa7320f35e1370ffe84e46ed4e2071fdc7e4b1a9b1f8ae9b",
+    "zh:5efb9da90f665e43f22c2e13e0ce48e86cae2d960aaf1abf721b497f32025916",
+    "zh:6f71257a6b1218d02a573fc9bff0657410404fb2ef23bc66ae8cd968f98d5ff6",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9647e18f221380a85f2f0ab387c68fdafd58af6193a932417299cdcae4710150",
+    "zh:bb6297ce412c3c2fa9fec726114e5e0508dd2638cad6a0cb433194930c97a544",
+    "zh:f83e925ed73ff8a5ef6e3608ad9225baa5376446349572c2449c0c0b3cf184b7",
+    "zh:fbef0781cb64de76b1df1ca11078aecba7800d82fd4a956302734999cfd9a4af",
+  ]
+}

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -1,6 +1,16 @@
+module "test" {
+  source                     = "../../"
+  cloudwatch_log_group_names = [aws_cloudwatch_log_group.test.name]
+  destination_bucket_arn     = aws_s3_bucket.test.arn
+  tags                       = local.tags
+}
 
-module "module_test" {
-  source           = "../../"
-  application_name = local.application_name
-  tags             = local.tags
+resource "aws_s3_bucket" "test" {
+  bucket_prefix = "test"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_log_group" "test" {
+  name_prefix = "test"
+  tags        = local.tags
 }


### PR DESCRIPTION
* Adds simple configuration for unit test
* Adds outputs to be used later by unit test
* Refactors `for_each` to use `count` instead.

Because supplying dynamic variables to a `for_each` can lead to an error like this:
```
│ Error: Invalid for_each argument
│ 
│   on ../../main.tf line 96, in resource "aws_cloudwatch_log_subscription_filter" "cloudwatch-to-firehose":
│   96:   for_each        = toset(var.cloudwatch_log_group_names)
│     ├────────────────
│     │ var.cloudwatch_log_group_names is list of string with 1 element
│ 
│ The "for_each" set includes values derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances
│ of this resource.
│ 
│ When working with unknown values in for_each, it's better to use a map value where the keys are defined statically in your configuration and where only the values contain apply-time results.
│ 
│ Alternatively, you could use the -target planning option to first apply only the resources that the for_each value depends on, and then apply a second time to fully converge.
```

This PR replaces the use of `for_each` for CloudWatch Log Group Subscription Filter resources with a simple `count`. This allows Terraform to successfully plan out this module without needing to resort to a targeted `apply` of the CloudWatch Log Groups that are to be passed in.