### PR TITLE
Add optional variable for compression format

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ No modules.
 | <a name="input_cloudwatch_filter_pattern"></a> [cloudwatch\_filter\_pattern](#input\_cloudwatch\_filter\_pattern) | A valid CloudWatch Logs filter pattern for subscribing to a filtered stream of log events. | `string` | `""` | no |
 | <a name="input_cloudwatch_log_group_names"></a> [cloudwatch\_log\_group\_names](#input\_cloudwatch\_log\_group\_names) | List of CloudWatch Log Group names to stream logs from. | `list(string)` | n/a | yes |
 | <a name="input_destination_bucket_arn"></a> [destination\_bucket\_arn](#input\_destination\_bucket\_arn) | ARN of the bucket for CloudWatch filters. | `string` | n/a | yes |
+| <a name="input_s3_compression_format"></a> [s3\_compression\_format](#input\_s3\_compression\_format) | Allow optional configuration of AWS Data Stream compression. Log Group subscription filters compress logs by default. | `string` | `"UNCOMPRESSED"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to be applied to resources. | `map(string)` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose-to-s3" {
     bucket_arn          = var.destination_bucket_arn
     buffering_size      = 64
     buffering_interval  = 60
-    compression_format  = "GZIP"
+    compression_format  = var.s3_compression_format
     role_arn            = aws_iam_role.firehose-to-s3.arn
     prefix              = "logs/!{timestamp:yyyy/MM/dd}/"
     error_output_prefix = "errors/!{firehose:error-output-type}/!{timestamp:yyyy/MM/dd}/"

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,12 @@ variable "cloudwatch_filter_pattern" {
   default     = ""
 }
 
+variable "s3_compression_format" {
+  type        = string
+  description = "Allow optional configuration of AWS Data Stream compression. Log Group subscription filters compress logs by default."
+  default     = "UNCOMPRESSED"
+}
+
 variable "tags" {
   type        = map(string)
   description = "Map of tags to be applied to resources."


### PR DESCRIPTION
Tracked through [#7185](https://github.com/ministryofjustice/modernisation-platform/issues/7185).

Because CloudWatch Log Group Subscription Filters compress data by default, double-compressing the content with the AWS Data Firehose can cause issues with third-party consumers of data.

This PR adds the following:
* An optional variable to set the compression format, with `UNCOMPRESSED` as the default.