### PR TITLE
Use aws secretmanager to store access credentials

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.70.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:+QN8de63DAE4QbyODwK14T9ZEKasvRwLMSItMOWoU2Q=",
+    "zh:09cbec93c324e6f03a866244ecb2bae71fdf1f5d3d981e858b745c90606b6b6d",
+    "zh:19685d9f4c9ddcfa476a9a428c6c612be4a1b4e8e1198fbcbb76436b735284ee",
+    "zh:3358ee6a2b24c982b7c83fac0af6898644d1bbdabf9c4e0589e91e427641ba88",
+    "zh:34f9f2936de7384f8ed887abdbcb54aea1ce7b0cf2e85243a3fd3904d024747f",
+    "zh:4a99546cc2140304c90d9ccb9db01589d4145863605a0fcd90027a643ea3ec5d",
+    "zh:4da32fec0e10dab5aa3dea3c9fe57adc973cc73a71f5d59da3f65d85d925dc3f",
+    "zh:659cf94522bc38ce0af70f7b0371b2941a0e0bcad02d17c1a7b264575fe07224",
+    "zh:6f1c172c9b98bc86e4f0526872098ee3246c2620f7b323ce0c2ce6427987f7d2",
+    "zh:79bf8fb8f37c308742e287694a9de081ff8502b065a390d1bcfbd241b4eca203",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b7a5e1dfd9e179d70a169ddd4db44b56da90309060e27d36b329fe5fb3528e29",
+    "zh:c2cc728cb18ffd5c4814a10c203452c71f5ab0c46d68f9aa9183183fa60afd87",
+    "zh:c89bb37d2b8947c9a0d62b0b86ace51542f3327970f4e56a68bf81d9d0b8b65b",
+    "zh:ef2a61e8112c3b5e70095508aadaadf077e904b62b9cfc22030337f773bba041",
+    "zh:f714550b858d141ea88579f25247bda2a5ba461337975e77daceaf0bb7a9c358",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.6.3"
+  constraints = "~> 3.4"
+  hashes = [
+    "h1:f6jXn4MCv67kgcofx9D49qx1ZEBv8oyvwKDMPBr0A24=",
+    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
+    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
+    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
+    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
+    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
+    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
+    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
+    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
+    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
+    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ If you're looking to raise an issue with this module, please create a new issue 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.4 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.70.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
 
 ## Modules
 
@@ -68,6 +68,7 @@ No modules.
 | [aws_kms_alias.firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_s3_bucket.firehose-errors](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_secretsmanager_secret.firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [random_id.name](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.cloudwatch-logs-role-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -84,7 +85,6 @@ No modules.
 | <a name="input_cloudwatch_log_group_names"></a> [cloudwatch\_log\_group\_names](#input\_cloudwatch\_log\_group\_names) | List of CloudWatch Log Group names to stream logs from. | `list(string)` | n/a | yes |
 | <a name="input_destination_bucket_arn"></a> [destination\_bucket\_arn](#input\_destination\_bucket\_arn) | ARN of the bucket for CloudWatch filters. | `string` | `""` | no |
 | <a name="input_destination_http_endpoint"></a> [destination\_http\_endpoint](#input\_destination\_http\_endpoint) | HTTP endpoint for CloudWatch filters. | `string` | `""` | no |
-| <a name="input_http_access_key"></a> [http\_access\_key](#input\_http\_access\_key) | Access key for HTTP Endpoint | `string` | `""` | no |
 | <a name="input_s3_compression_format"></a> [s3\_compression\_format](#input\_s3\_compression\_format) | Allow optional configuration of AWS Data Stream compression. Log Group subscription filters compress logs by default. | `string` | `"UNCOMPRESSED"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to be applied to resources. | `map(string)` | n/a | yes |
 
@@ -98,6 +98,7 @@ No modules.
 | <a name="output_iam_roles"></a> [iam\_roles](#output\_iam\_roles) | n/a |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | n/a |
 | <a name="output_log_subscriptions"></a> [log\_subscriptions](#output\_log\_subscriptions) | n/a |
+| <a name="output_secretsmanager_secret_arn"></a> [secretsmanager\_secret\_arn](#output\_secretsmanager\_secret\_arn) | n/a |
 <!-- END_TF_DOCS -->
 
 [Standards Link]: https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-report/modernisation-platform-terraform-module-template "Repo standards badge."

--- a/README.md
+++ b/README.md
@@ -6,19 +6,26 @@
 
 ```hcl
 
-module "example" {
-
+module "example-s3" {
   source                     = "github.com/ministryofjustice/modernisation-platform-terraform-aws-data-firehose"
   cloudwatch_log_group_names = ["example-1", "example-2", "example-3"]
   destination_bucket_arn     = aws_s3_bucket.example.arn
   tags                       = local.tags
+}
 
+module "example-http" {
+  source                     = "github.com/ministryofjustice/modernisation-platform-terraform-aws-data-firehose"
+  cloudwatch_log_group_names = ["example-1", "example-2", "example-3"]
+  destination_http_endpoint  = "https://example-url.com/endpoint"
+  tags                       = local.tags
 }
 
 ```
 
 This module creates an [AWS Data Stream](https://aws.amazon.com/kinesis/data-streams/) to be used by a set of AWS CloudWatch Log Groups.
-Data is streamed from the Log Groups to a target S3 bucket using a Cloudwatch Log Subscription Filter.
+Data is streamed from the Log Groups to either a target S3 bucket or HTTP endpoint using a Cloudwatch Log Subscription Filter.
+
+When a HTTP endpoint is specified, an `aws_secretsmanager_secret` resource is created that is polled at 10 minute intervals for credentials.
 
 Included in this module are the necessary IAM policy documents and roles for these actions, as well as a KMS key to encrypt the Data Stream.
 

--- a/data.tf
+++ b/data.tf
@@ -91,6 +91,16 @@ data "aws_iam_policy_document" "firehose-role-policy" {
       "${aws_cloudwatch_log_group.kinesis.arn}:log-stream:DestinationDelivery"
     ]
   }
+  statement {
+    sid    = "FirehoseReadSecret"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+    resources = [
+      aws_secretsmanager_secret.firehose.arn
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "firehose-key-policy" {

--- a/main.tf
+++ b/main.tf
@@ -101,8 +101,8 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose" {
       }
 
       secrets_manager_configuration {
-        enabled = true
-        role_arn = aws_iam_role.firehose.arn
+        enabled    = true
+        role_arn   = aws_iam_role.firehose.arn
         secret_arn = aws_secretsmanager_secret.firehose.arn
       }
     }
@@ -118,9 +118,9 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose" {
 }
 
 resource "aws_secretsmanager_secret" "firehose" {
-  name_prefix = "cloudwatch-export-${random_id.name.hex}"
+  name_prefix             = "cloudwatch-export-${random_id.name.hex}"
   recovery_window_in_days = 0
-  tags = var.tags
+  tags                    = var.tags
 }
 
 resource "aws_s3_bucket" "firehose-errors" {

--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,6 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose" {
   dynamic "http_endpoint_configuration" {
     for_each = var.destination_http_endpoint != "" ? [1] : []
     content {
-      access_key         = sensitive(var.http_access_key)
       buffering_size     = 1
       buffering_interval = 60
       name               = var.destination_http_endpoint
@@ -100,6 +99,12 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose" {
       request_configuration {
         content_encoding = "GZIP"
       }
+
+      secrets_manager_configuration {
+        enabled = true
+        role_arn = aws_iam_role.firehose.arn
+        secret_arn = aws_secretsmanager_secret.firehose.arn
+      }
     }
   }
 
@@ -109,6 +114,12 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose" {
     key_arn  = aws_kms_key.firehose.arn
   }
 
+  tags = var.tags
+}
+
+resource "aws_secretsmanager_secret" "firehose" {
+  name_prefix = "cloudwatch-export-${random_id.name.hex}"
+  recovery_window_in_days = 0
   tags = var.tags
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,3 +24,7 @@ output "iam_roles" {
 output "firehose_server_side_encryption_key_arn" {
   value = aws_kinesis_firehose_delivery_stream.firehose.server_side_encryption[0].key_arn
 }
+
+output "secretsmanager_secret_arn" {
+  value = aws_secretsmanager_secret.firehose.arn
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,12 +6,8 @@ output "data_stream" {
   value = aws_kinesis_firehose_delivery_stream.firehose.id
 }
 
-output "kms_key_arn" {
-  value = aws_kms_key.firehose.arn
-}
-
-output "log_subscriptions" {
-  value = aws_cloudwatch_log_subscription_filter.cloudwatch-to-firehose
+output "firehose_server_side_encryption_key_arn" {
+  value = aws_kinesis_firehose_delivery_stream.firehose.server_side_encryption[0].key_arn
 }
 
 output "iam_roles" {
@@ -21,8 +17,12 @@ output "iam_roles" {
   }
 }
 
-output "firehose_server_side_encryption_key_arn" {
-  value = aws_kinesis_firehose_delivery_stream.firehose.server_side_encryption[0].key_arn
+output "kms_key_arn" {
+  value = aws_kms_key.firehose.arn
+}
+
+output "log_subscriptions" {
+  value = aws_cloudwatch_log_subscription_filter.cloudwatch-to-firehose
 }
 
 output "secretsmanager_secret_arn" {

--- a/test/module_test.go
+++ b/test/module_test.go
@@ -27,20 +27,24 @@ func TestModule(t *testing.T) {
 	assert.Contains(t, dataStream["http"], "cloudwatch-export", "HTTP Data stream ARN should contain 'cloudwatch-export'")
 	assert.Contains(t, dataStream["s3"], "cloudwatch-export", "S3 Data stream ARN should contain 'cloudwatch-export'")
 
+	// Test IAM Roles exist
+	iamRoles := terraform.OutputMap(t, terraformOptions, "iam_roles")
+	assert.NotEmpty(t, iamRoles["http"], "HTTP IAM roles should not be empty")
+	assert.NotEmpty(t, iamRoles["s3"], "S3 IAM roles should not be empty")
+
 	// Test KMS Key ARN and Firehose Server Side Encryption Key ARN match
 	kmsKeyArn := terraform.OutputMap(t, terraformOptions, "kms_key_arn")
 	firehoseServerSideEncryptionKeyArn := terraform.OutputMap(t, terraformOptions, "firehose_server_side_encryption_key_arn")
 	assert.Contains(t, firehoseServerSideEncryptionKeyArn["http"], kmsKeyArn["http"], "HTTP Encryption keys do not match")
 	assert.Contains(t, firehoseServerSideEncryptionKeyArn["s3"], kmsKeyArn["s3"], "S3 Encryption keys do not match")
 
-	// Test IAM Roles exist
-	iamRoles := terraform.OutputMap(t, terraformOptions, "iam_roles")
-	assert.NotEmpty(t, iamRoles["http"], "HTTP IAM roles should not be empty")
-	assert.NotEmpty(t, iamRoles["s3"], "S3 IAM roles should not be empty")
-
 	// Test Log Subscriptions exist
 	logSubscriptions := terraform.OutputMap(t, terraformOptions, "log_subscriptions")
 	assert.NotEmpty(t, logSubscriptions["http"], "HTTP Log subscriptions should not be empty")
 	assert.NotEmpty(t, logSubscriptions["s3"], "S3 Log subscriptions should not be empty")
+
+   // Test Secret is created for HTTP module
+	secretsmanagerSecretArn := terraform.OutputMap(t, terraformOptions, "secretsmanager_secret_arn")
+	assert.Contains(t, secretsmanagerSecretArn["http"], "secret:cloudwatch-export", "HTTP Secretsmanager ARN should contain 'secret:cloudwatch-export'")
 
 }

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -10,7 +10,6 @@ module "test-http" {
   source                     = "../../"
   cloudwatch_log_group_names = [aws_cloudwatch_log_group.test.name]
   destination_http_endpoint  = "https://test.xyz/abc123"
-  http_access_key            = "123456"
   tags                       = local.tags
 }
 

--- a/test/unit-test/outputs.tf
+++ b/test/unit-test/outputs.tf
@@ -14,22 +14,22 @@ output "data_stream" {
   value = { for key, value in local.modules : key => value.data_stream }
 }
 
-output "iam_roles" {
-  value = { for key, value in local.modules : key => value.iam_roles }
+output "firehose_server_side_encryption_key_arn" {
+  value = { for key, value in local.modules : key => value.firehose_server_side_encryption_key_arn }
 }
 
-output "log_subscriptions" {
-  value = { for key, value in local.modules : key => value.log_subscriptions }
+output "iam_roles" {
+  value = { for key, value in local.modules : key => value.iam_roles }
 }
 
 output "kms_key_arn" {
   value = { for key, value in local.modules : key => value.kms_key_arn }
 }
 
-output "firehose_server_side_encryption_key_arn" {
-  value = { for key, value in local.modules : key => value.firehose_server_side_encryption_key_arn }
+output "log_subscriptions" {
+  value = { for key, value in local.modules : key => value.log_subscriptions }
 }
 
 output "secretsmanager_secret_arn" {
-  value = { for key, value in local.modules : key => value.secretsmanager_secret_arn}
+  value = { for key, value in local.modules : key => value.secretsmanager_secret_arn }
 }

--- a/test/unit-test/outputs.tf
+++ b/test/unit-test/outputs.tf
@@ -29,3 +29,7 @@ output "kms_key_arn" {
 output "firehose_server_side_encryption_key_arn" {
   value = { for key, value in local.modules : key => value.firehose_server_side_encryption_key_arn }
 }
+
+output "secretsmanager_secret_arn" {
+  value = { for key, value in local.modules : key => value.secretsmanager_secret_arn}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -21,14 +21,6 @@ variable "destination_http_endpoint" {
   default     = ""
 }
 
-# Temporary while I properly implement secrets_manager_configuration
-variable "http_access_key" {
-  type        = string
-  description = "Access key for HTTP Endpoint"
-  default     = ""
-  sensitive   = true
-}
-
 variable "s3_compression_format" {
   type        = string
   description = "Allow optional configuration of AWS Data Stream compression. Log Group subscription filters compress logs by default."


### PR DESCRIPTION
This PR implements the use of AWS Secretsmanager to store HTTP endpoint access credentials as discussed in [this AWS Documentation](https://docs.aws.amazon.com/firehose/latest/dev/using-secrets-manager.html).

The PR does the following:
* Creates an `aws_secretsmanager_secret` resource as a container for the credentials.
* Updates the `firehose-role-policy` document to allow access from firehose to the secret.
* Updates the dynamic block for `http_endpoint_configuration` to reference this new secret and role.
* Removes a now unused variable: `http_access_key`.
* Alphabetises the outputs.
* Alphabetises the unit tests.