### PR TITLE
TM-1296: allow user friendly secret names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Modernisation Platform Terraform Module Template 
+# Modernisation Platform Terraform Module Template
 
 [![Standards Icon]][Standards Link] [![Format Code Icon]][Format Code Link] [![Scorecards Icon]][Scorecards Link] [![SCA Icon]][SCA Link] [![Terraform SCA Icon]][Terraform SCA Link]
 
@@ -10,14 +10,17 @@ module "example-s3" {
   source                     = "github.com/ministryofjustice/modernisation-platform-terraform-aws-data-firehose"
   cloudwatch_log_group_names = ["example-1", "example-2", "example-3"]
   destination_bucket_arn     = aws_s3_bucket.example.arn
+  name                       = "example-s3" # optionally provide name for more descriptive resource names
   tags                       = local.tags
 }
 
 module "example-http" {
-  source                     = "github.com/ministryofjustice/modernisation-platform-terraform-aws-data-firehose"
-  cloudwatch_log_group_names = ["example-1", "example-2", "example-3"]
-  destination_http_endpoint  = "https://example-url.com/endpoint"
-  tags                       = local.tags
+  source                       = "github.com/ministryofjustice/modernisation-platform-terraform-aws-data-firehose"
+  cloudwatch_log_group_names   = ["example-1", "example-2", "example-3"]
+  destination_http_endpoint    = "https://example-url.com/endpoint"
+  destination_http_secret_name = "http-api-keys/example" # optionally specify name of secret to create
+  name                         = "example-http"          # optionally provide name for more descriptive resource names
+  tags                         = local.tags
 }
 
 ```
@@ -28,6 +31,7 @@ Data is streamed from the Log Groups to either a target S3 bucket or HTTP endpoi
 When a HTTP endpoint is specified, an `aws_secretsmanager_secret` resource is created that is polled at 10 minute intervals for credentials.
 
 The `aws_secretsmanager_secret` **value** must be populated independently of this module.
+See [AWS Firehose Secrets](https://docs.aws.amazon.com/firehose/latest/dev/secrets-manager-whats-secret.html) for details of the format.
 
 Included in this module are the necessary IAM policy documents and roles for these actions, as well as a KMS key to encrypt the Data Stream.
 
@@ -90,6 +94,8 @@ No modules.
 | <a name="input_cloudwatch_log_group_names"></a> [cloudwatch\_log\_group\_names](#input\_cloudwatch\_log\_group\_names) | List of CloudWatch Log Group names to stream logs from. | `list(string)` | n/a | yes |
 | <a name="input_destination_bucket_arn"></a> [destination\_bucket\_arn](#input\_destination\_bucket\_arn) | ARN of the bucket for CloudWatch filters. | `string` | `""` | no |
 | <a name="input_destination_http_endpoint"></a> [destination\_http\_endpoint](#input\_destination\_http\_endpoint) | HTTP endpoint for CloudWatch filters. | `string` | `""` | no |
+| <a name="input_destination_http_secret_name"></a> [destination\_http\_secret\_name](#input\_destination\_http\_secret\_name) | Name of secret to create for http endpoint. Set the value outside of terraform, see https://docs.aws.amazon.com/firehose/latest/dev/secrets-manager-whats-secret.html | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Optionally provide unique name to help identify resources when multiple instances of module are created, e.g. 'syslog' | `string` | `null` | no |
 | <a name="input_s3_compression_format"></a> [s3\_compression\_format](#input\_s3\_compression\_format) | Allow optional configuration of AWS Data Stream compression. Log Group subscription filters compress logs by default. | `string` | `"UNCOMPRESSED"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to be applied to resources. | `map(string)` | n/a | yes |
 

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,18 @@ variable "destination_http_endpoint" {
   default     = ""
 }
 
+variable "destination_http_secret_name" {
+  type        = string
+  description = "Name of secret to create for http endpoint. Set the value outside of terraform, see https://docs.aws.amazon.com/firehose/latest/dev/secrets-manager-whats-secret.html"
+  default     = null
+}
+
+variable "name" {
+  type        = string
+  description = "Optionally provide unique name to help identify resources when multiple instances of module are created, e.g. 'syslog'"
+  default     = null
+}
+
 variable "s3_compression_format" {
   type        = string
   description = "Allow optional configuration of AWS Data Stream compression. Log Group subscription filters compress logs by default."


### PR DESCRIPTION
If you have multiple instances of the module, it's difficult to see which resources are for which log group with the current module. Adding a couple of options to improve this:
- name: use a descriptive name, e.g. "syslog" for the resource names
- destination_http_secret_name: specify your own secret name, e.g. to stay consistent with your own secret naming

This is backward compatible, i.e. no breaking changes, but the cloudwatch log group will be re-created using a name_prefix to be consistent with other resources if var.name is not specified.
Tested in nomis-development with and without the new options.