### PR TITLE
Migrate TSA from github-action to MP-github-actions

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Analysis
-        uses: ministryofjustice/github-actions/terraform-static-analysis@db1a54895bf5fb975c60af47e5a3aab96505ca3e # v18.6.0
+        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@2d1bb8ef39861ede2999271b530cb9dd87f18004 # v3.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -52,7 +52,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Analysis
-        uses: ministryofjustice/github-actions/terraform-static-analysis@db1a54895bf5fb975c60af47e5a3aab96505ca3e # v18.6.0
+        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@2d1bb8ef39861ede2999271b530cb9dd87f18004 # v3.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This PR updates the .github/workflows/terraform-static-analysis.yml workflow to use the migrated version now offered from https://github.com/ministryofjustice/modernisation-platform-github-actions/tree/main/terraform-static-analysis