### PR TITLE
Add KMS permissions to CloudWatch-to-Firehose IAM role for SSE-CMK compliance

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -34,6 +34,16 @@ data "aws_iam_policy_document" "cloudwatch-logs-role-policy" {
       aws_kinesis_firehose_delivery_stream.firehose.arn
     ]
   }
+
+  statement {
+    sid    = "UseFirehoseKMSKey"
+    effect = "Allow"
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt"
+    ]
+    resources = [aws_kms_key.firehose.arn]
+  }
 }
 
 data "aws_iam_policy_document" "firehose-trust-policy" {


### PR DESCRIPTION
## What?
Add kms:GenerateDataKey and kms:Decrypt permissions to the cloudwatch-logs-role-policy IAM policy document in data.tf.

## Why?
AWS is enforcing a new requirement (effective February 28, 2027) that all principals calling PutRecord/PutRecordBatch on SSE-CMK enabled Firehose delivery streams must have kms:GenerateDataKey and kms:Decrypt in their IAM identity policy.

We have received a health warning for this for one of our resources in `core-network-services`: https://mojdt.slack.com/archives/C0A3B5K1FR6/p1779089035717419

The cloudwatch-to-firehose role is the principal making these calls. While the KMS key policy already grants this role the necessary KMS permissions, IAM requires both the key policy and the identity policy to allow the action. The role policy currently only grants firehose:PutRecord and firehose:PutRecordBatch, so the KMS side is missing.

Without this fix, callers will receive AccessDenied from KMS after the enforcement date.

## Changes
Added `kms:GenerateDataKey` and `kms:Decrypt` on `aws_kms_key.firehose` to the `cloudwatch-logs-role-policy` policy document
