### PR TITLE
Adds dependabot cooldown feature

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,14 @@ version: 2
 updates:
   - package-ecosystem: "terraform"
     directory: "/"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "daily"
     groups:
@@ -14,6 +18,8 @@ updates:
           - "*"
   - package-ecosystem: "gomod"
     directory: "/test"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "daily"
     groups:


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/12036

## How does this PR fix the problem?

Adds Dependabot cooldown configuration so newly released dependency versions must now wait 7 days by default before 
Dependabot raises a version-update PR 